### PR TITLE
Expose the Hailo append function

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3373,6 +3373,7 @@ ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_CUDA, _In_ OrtSessionOpt
 */
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_MIGraphX, _In_ OrtSessionOptions* options, int device_id);
 
+ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Hailo, _In_ OrtSessionOptions* options, int use_arena);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Description**: Publish the `OrtSessionOptionsAppendExecutionProvider_Hailo` function.

**Motivation and Context**
We are using this function to enable hailo as an execution provider in our inference server when needed.
Without publishing the function this way, we will get a `was not declared in this scope` error when building the inference server.
